### PR TITLE
Only watch for entries in packages/ directory, prevent recursion

### DIFF
--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -32,7 +32,9 @@ export class PackageManager extends EventEmitter {
         this.storage = storage;
         this.packages = {};
         this.version = version;
-        this.pckdir_watch = chokidar.watch(storage);
+        this.pckdir_watch = chokidar.watch(storage, {
+            depth: 1,
+        });
         this.ready = false;
 
         this.pckdir_watch.on('addDir', async (pathDir) => {


### PR DESCRIPTION
If a package contains a lot of files (for example @mdi/svg under
node_modules/), the number of watchers that are created is very large.

Depending on the system configuration, the following error may get
reported, which causes CamScripter to error out:

    node:internal/errors:464
        ErrorCaptureStackTrace(err);
        ^

    Error: ENOSPC: System limit for number of file watchers reached, watch '/usr/local/lib/node_modules/camscripter-raspberry/packages/CamStreamDeckControl/node_modules/pako/lib/zlib/gzheader.js'
        at FSWatcher.<computed> (node:internal/fs/watchers:244:19)

There is no need to watch the contents of the micro app, reducing the
depth to 1 (instead of the default 'undefined') only allocates 8
watchers, where with the default value over 12000 are created.

### Analysis and Verification

This has been tested by running the container-image from https://github.com/nixpanic/camscripter-container , and installing a micro app that uses `@mdi/svg`.

The `camscripter-raspberry` process has `pid=8`:
```
      8 pts/0    Sl+    1:23 /usr/bin/node /usr/local/lib/node_modules/camscripter-raspberry/dist/main.js
```
The process has a single file-descriptor open that handles the watchers:
```
# ls -l /proc/8/fd | grep inotify
lr-x------. 1 root root 64 Mar 10 14:16 19 -> anon_inode:inotify
```
The number of watchers can be found by checking the related `fdinfo` file:
```
# grep -c ^inotify /proc/8/fdinfo/19
12292
```

With this change, the number of watchers (while running the test micro app) reduces to 8!