### PR TITLE
PackageManager: fix regression in storage watching

### DIFF
--- a/src/packageManager.ts
+++ b/src/packageManager.ts
@@ -35,7 +35,7 @@ export class PackageManager extends EventEmitter {
         this.version = version;
         this.ready = false;
 
-        this.pckdir_watch = chokidar.watch(storage, { depth: 0 });
+        this.pckdir_watch = chokidar.watch(`${storage}/*`, { depth: 0 });
         this.pckdir_watch.on('addDir', async (path_dir) => {
             let parsed = path.parse(path_dir);
             logger.logInfo('Package added ' + parsed.name);


### PR DESCRIPTION
When creating a watcher for the `${storage}` path, the last component of
the path is reported as a new package. This results in the following
error:

```
Package added packages
node:fs:585
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, open '/usr/local/lib/node_modules/camscripter-raspberry/packages/packages/manifest.json'
    at Object.openSync (node:fs:585:3)
    at Object.readFileSync (node:fs:453:35)
    at Package.readManifest (/usr/local/lib/node_modules/camscripter-raspberry/dist/packageManager.js:189:31)
    at new Package (/usr/local/lib/node_modules/camscripter-raspberry/dist/packageManager.js:161:30)
    at PackageManager.<anonymous> (/usr/local/lib/node_modules/camscripter-raspberry/dist/packageManager.js:40:42)
    at Generator.next (<anonymous>)
    at fulfilled (/usr/local/lib/node_modules/camscripter-raspberry/dist/packageManager.js:5:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/usr/local/lib/node_modules/camscripter-raspberry/packages/packages/manifest.json'
}
```

By watching `${storage}/*` instead, the non-existing package named
`package` is not getting added anymore.