### PR TITLE
http-server: enable serving of .ttf font files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ const ext_map = {
     '.svg': 'image/svg+xml',
     '.pdf': 'application/pdf',
     '.doc': 'application/msword',
+    '.ttf': 'font/sfnt',
 };
 
 const pckg_manager = new PackageManager(


### PR DESCRIPTION
When a micro app tries to use its own font, the webserver crashes with
the following stack:

    Http-Server: Incomming request /local/camscripter/package/test-app/the-font.ttf
    node:_http_outgoing:566
        throw new ERR_HTTP_INVALID_HEADER_VALUE(value, name);
        ^

    TypeError [ERR_HTTP_INVALID_HEADER_VALUE]: Invalid value "undefined" for header "Content-Type"
        at storeHeader (node:_http_outgoing:519:5)
        at processHeader (node:_http_outgoing:514:3)
        at ServerResponse._storeHeader (node:_http_outgoing:411:11)
        at ServerResponse.writeHead (node:_http_server:347:8)
        at HttpServer.<anonymous> (/usr/local/lib/node_modules/camscripter-raspberry/dist/main.js:57:25)
        at HttpServer.emit (node:events:520:28)
        at Server.<anonymous> (/usr/local/lib/node_modules/camscripter-raspberry/dist/httpServer.js:44:22)
        at Server.emit (node:events:520:28)
        at parserOnIncoming (node:_http_server:951:12)
        at HTTPParser.parserOnHeadersComplete (node:_http_common:128:17) {
      code: 'ERR_HTTP_INVALID_HEADER_VALUE'

By adding the .ttf extension to `ext_map` the webserver is able to pass
the font to the client, and does not crash anymore.