### PR TITLE
passwords can now contain @ and similar symbols

### DIFF
--- a/src/httpProxy.ts
+++ b/src/httpProxy.ts
@@ -50,7 +50,7 @@ export class HttpProxy {
                 host: target.host,
                 port: target.port,
                 path: target.path,
-                auth: encodeURIComponent(target.username) + ':' + encodeURIComponent(target.password),
+                auth: target.username + ':' + target.password,
                 timeout: 10000,
                 headers: req.headers,
                 rejectUnauthorized: target.protocol === 'https',


### PR DESCRIPTION
Previously passwords could not contain any symbols that `encodeURIComponent` would encode (`@`, `#`, ...), because it would calculate the _Authorization_ header from the encoded version and that was wrong. 
`auth` is not used in the url and therefore it does not need encoding. (source: https://nodejs.org/api/http.html#http_http_request_options_callback )
`:` is not a problem. In passwords I tested it and it worked and (on my camera) I am unable to create an account with `:` in the username.