### PR TITLE
Reset file listeners when importing settings

### DIFF
--- a/src/httpApi.ts
+++ b/src/httpApi.ts
@@ -360,6 +360,9 @@ export class HttpApi {
                         await fs.remove(filePath);
                     }
                 }
+                this.pckgManager.setSettingsListeners();
+                pckg.restart('SIGINT');
+
                 sendMessageResponse(res, returnCode, returnMessage);
                 break;
             }


### PR DESCRIPTION
When settings are imported from a zip file, the whole file gets deleted and then copied from the zip. That caused the listeners to disconnect and therefore changes stopped being detected.

Steps to reproduce (maybe not the shortest path):
1. Uninstall package
2. Reinstall package
3. Turn the package on
4. Import settings
5. Updating settings no longer works until one restarts the package